### PR TITLE
feat: conditionally dump environment variables in node_env metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ export default defineConfig({
 | prefix        | Custom metric prefix name                                 | `pw_`                                |
 | auth.username | Basic auth. username                                      | undefined                            |
 | auth.password | Basic auth. password                                      | undefined                            |
+| nodeEnvEnable | Dumps all envvars to `node_env` metric                    | false                                |
 
 ## Collected metrics
 
@@ -105,7 +106,7 @@ This metrics collects every reporter lifecycle.
 | node_memory_rss           | memory usage of the Node.js process measured in bytes [7]                            | process.memotyUsage |
 | node_memory_heap_total    | memory usage of the Node.js process measured in bytes [7]                            | process.memotyUsage |
 
-[1]: Do not use "process.env.name" variable since it can overwrite your "node_env" metric.
+[1]: Do not use "process.env.name" variable since it can overwrite your "node_env" metric. Conditionally enabled with `nodeEnvEnable` from reporter configuration as it can leak secrets into Prometheus metrics
 
 [2]: docs: https://nodejs.org/docs/latest/api/process.html#processenv
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,13 +252,12 @@ export default class PrometheusReporter implements Reporter {
       this.node_memory_heap_used._getSeries(),
       this.node_memory_rss._getSeries(),
       this.node_os._getSeries(),
-      this.node_env._getSeries(),
       this.node_argv._getSeries(),
       this.node_versions._getSeries(),
     ];
     
     // Conditionally include node_env series
-    if (this.options.nodeEnvEnable) {
+    if (this.options.nodeEnvEnable == true) {
       stats.push(this.node_env._getSeries());
     }
     


### PR DESCRIPTION
By default, the module will dump all environment variables to Prometheus metrics and this can embed secrets for example.
For security, this is better to conditionally dump those variables. `nodeEnvEnable` has been created in options and is `false` by default. If needed, it can be set as `true` for debugging purposes only